### PR TITLE
Fixed run order for empty_return_path

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ exports.register = function () {
   this.register_hook('rcpt_ok', 'bad_rcpt')
   this.register_hook('data', 'single_recipient')
   this.register_hook('data', 'bounce_spf_enable')
-  // must run before the Headers plugin's invalid_return_path() as it removes Return-Path headers.
-  this.register_hook('data_post', 'empty_return_path', 25)
+  // must run before the Headers plugin's invalid_return_path() which removes Return-Path headers.
+  this.register_hook('data_post', 'empty_return_path', -5)
   this.register_hook('data_post', 'create_validation_hash')
   this.register_hook('data_post', 'validate_bounce')
   this.register_hook('data_post', 'validate_date')


### PR DESCRIPTION
empty_return_path must run before the Headers plugin's invalid_return_path which removes Return-Path headers.
