### PR TITLE
Added test coverage and fixed a few bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- moved null sender check to hook_mail (check_null_sender)
+- exported extract_header() for testing
+- removed check.hash_date and reject.hash_date
+- will always reject bounces with expired or invalid date header
+- added test coverage
+- refactored load_bounce_whitelist
+- refactored extract_header to correctly capture folded headers
+- fixed some testing bugs
+- added test coverage
+- added tests
+- removed config options to check/reject if Date header is too old or invalid. now always reject bounces with expired or invalid date header.
+- bumped version to 2.1.3
+
 ### [2.1.2] - 2026-03-03
 
 - fix: isa was boolean, revert change from #4 to yes/no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - refactored load_bounce_whitelist
 - refactored extract_header to correctly capture folded headers
 - fixed some testing bugs
-- added test coverage
 - added tests
-- removed config options to check/reject if Date header is too old or invalid. now always reject bounces with expired or invalid date header.
+- removed config options to check/reject if Date header is too old or invalid and will always reject bounces with expired or invalid date header.
 - bumped version to 2.1.3
 
 ### [2.1.2] - 2026-03-03

--- a/config/bounce.ini
+++ b/config/bounce.ini
@@ -21,9 +21,6 @@ hash_algorithm=sha256
 ; Enable hash validation for outbound mail and verification for inbound bounces
 ; hash_validation=false
 
-; Check if the bounce is newer than max_hash_age_days
-; hash_date=true
-
 [reject]
 ; Reject bounces with multiple recipients
 ; single_recipient=true
@@ -42,9 +39,6 @@ hash_algorithm=sha256
 
 ; Reject bounces with invalid/missing validation hash
 ; hash_validation=false
-
-; Reject bounces older than max_hash_age_days
-; hash_date=false
 
 [skip]
 ; Skip remaining plugins when bounce passes validation

--- a/index.js
+++ b/index.js
@@ -122,13 +122,14 @@ exports.load_bounce_whitelist = function () {
  * Note: This only applies to inbound messages with a null sender.
  */
 exports.check_null_sender = function (next, connection) {
-  if (!connection.relaying) {
-    const is_null_sender = connection.transaction.mail_from.isNull() ? 'yes' : 'no'
-    connection.transaction.results.add(this, {
-      isa: is_null_sender,
-      emit: true,
-    })
-  }
+  if (!connection?.transaction?.mail_from) return next()
+
+  const is_null_sender = connection.transaction.mail_from.isNull() ? 'yes' : 'no'
+  connection.transaction.results.add(this, {
+    isa: is_null_sender,
+    emit: true,
+  })
+
   next()
 }
 

--- a/index.js
+++ b/index.js
@@ -54,34 +54,34 @@ exports.load_bounce_ini = function () {
 }
 
 exports.validate_config = function () {
-  const { check, reject } = this.cfg
+  const { check, reject, validation } = this.cfg
 
   // checks need to be enabled for rejects to work
   for (const key of ['single_recipient', 'empty_return_path', 'bounce_spf', 'hash_validation']) {
     if (reject[key] && !check[key]) check[key] = true
   }
 
-  if (!this.cfg.check.hash_validation) return
-  if (!this.cfg.validation.max_hash_age_days) this.cfg.validation.max_hash_age_days = MAX_HASH_AGE_DAYS
-  if (!this.cfg.validation.hash_algorithm) this.cfg.validation.hash_algorithm = 'sha256'
+  if (!check.hash_validation) return
+  if (!validation.max_hash_age_days) validation.max_hash_age_days = MAX_HASH_AGE_DAYS
+  if (!validation.hash_algorithm) validation.hash_algorithm = 'sha256'
 
   // confirm that hash algorithm is supported
   const algorithms = crypto.getHashes()
-  if (!algorithms.includes(this.cfg.validation.hash_algorithm)) {
-    this.logerror(`Bounce validation disabled due to invalid hash algorithm: ${this.cfg.validation.hash_algorithm}`)
-    this.cfg.check.hash_validation = false
+  if (!algorithms.includes(validation.hash_algorithm)) {
+    this.logerror(`Bounce validation disabled due to invalid hash algorithm: ${validation.hash_algorithm}`)
+    check.hash_validation = false
     return
   }
 
-  if (!this.cfg.validation.secret || this.cfg.validation.secret === 'your_generated_secret_here') {
+  if (!validation.secret || validation.secret === 'your_generated_secret_here') {
     this.logerror(`Bounce validation disabled due to missing secret.`)
-    this.cfg.check.hash_validation = false
+    check.hash_validation = false
     return
   }
 
-  if (this.cfg.validation.secret.length < 32) {
+  if (validation.secret.length < 32) {
     this.logerror('Bounce validation disabled due to secret that is too short.')
-    this.cfg.check.hash_validation = false
+    check.hash_validation = false
     return
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ exports.register = function () {
   this.load_bounce_ini()
   this.load_bounce_bad_rcpt()
   this.load_bounce_whitelist()
+  this.validate_config()
 
+  this.register_hook('mail', 'check_null_sender', -5)
   this.register_hook('mail', 'reject_all')
   this.register_hook('rcpt_ok', 'bad_rcpt')
   this.register_hook('data', 'single_recipient')
@@ -32,7 +34,6 @@ exports.load_bounce_ini = function () {
         '-check.empty_return_path',
         '+check.bounce_spf',
         '-check.hash_validation',
-        '+check.hash_date',
 
         '+reject.single_recipient',
         '-reject.empty_return_path',
@@ -40,15 +41,12 @@ exports.load_bounce_ini = function () {
         '+reject.bad_rcpt',
         '-reject.all_bounces',
         '-reject.hash_validation',
-        '-reject.hash_date',
 
         '-skip.remaining_plugins',
       ],
     },
     () => this.load_bounce_ini(),
   )
-
-  this.validate_config()
 
   // legacy settings
   const c = this.cfg
@@ -74,10 +72,6 @@ exports.validate_config = function () {
   }
 
   if (!this.cfg.check.hash_validation) return
-
-  if (this.cfg.reject.hash_date && !this.cfg.check.hash_date) {
-    this.cfg.check.hash_date = true
-  }
 
   // confirm that hash algorithm is supported
   const algorithms = crypto.getHashes()
@@ -109,9 +103,41 @@ exports.load_bounce_bad_rcpt = function () {
 }
 
 exports.load_bounce_whitelist = function () {
-  this.cfg.whitelist = this.config.get('bounce_whitelist.json', () => {
+  const whitelist = this.config.get('bounce_whitelist.json', () => {
     this.load_bounce_whitelist()
   })
+
+  // Lowercase all recipient keys and sender values for case-insensitive matching
+  this.cfg.whitelist = {}
+  if (whitelist && typeof whitelist === 'object') {
+    for (const [rcpt, senders] of Object.entries(whitelist)) {
+      if (Array.isArray(senders)) {
+        this.cfg.whitelist[rcpt.toLowerCase()] = senders.map((s) => s.toLowerCase())
+      }
+    }
+  }
+}
+
+/*
+ * Checks message for null sender (bounces have a null sender)
+ *
+ * Special cases:
+ * - Microsoft Exchange will send mail to distribution groups using a
+ *   null sender if the "report_to_originator_enabled" property is false.
+ * - Some email providers (e.g., gmx.net) send DMARC reports with a null sender
+ * - Some auto-responders send replies with a null sender
+ *
+ * Note: This only applies to inbound messages with a null sender.
+ */
+exports.check_null_sender = function (next, connection) {
+  if (!connection.relaying) {
+    const is_null_sender = connection.transaction.mail_from.isNull() ? 'yes' : 'no'
+    connection.transaction.results.add(this, {
+      isa: is_null_sender,
+      emit: true,
+    })
+  }
+  next()
 }
 
 /*
@@ -245,7 +271,7 @@ exports.bad_rcpt = function (next, connection, rcpt) {
 
   const { transaction } = connection
 
-  if (this.cfg.invalid_addrs.includes(rcpt.address().toLowerCase())) {
+  if (this.cfg.invalid_addrs?.includes(rcpt.address().toLowerCase())) {
     transaction.results.add(this, {
       fail: 'bad_rcpt',
       msg: 'rcpt does not accept bounces',
@@ -257,24 +283,6 @@ exports.bad_rcpt = function (next, connection, rcpt) {
   transaction.results.add(this, { pass: 'bad_rcpt' })
 
   next()
-}
-
-/*
- * Checks message for null sender (bounces have a null sender)
- *
- * Special cases:
- * - Microsoft Exchange will send mail to distribution groups using a
- *   null sender if the "report_to_originator_enabled" property is false.
- * - Some email providers (e.g., gmx.net) send DMARC reports with a null sender
- * - Some auto-responders send replies with a null sender
- *
- * Note: This only applies to inbound messages with a null sender.
- */
-exports.has_null_sender = function (transaction) {
-  // Bounces have a null sender.
-  const is_null_sender = !!transaction.mail_from.isNull()
-  transaction.results.add(this, { isa: is_null_sender })
-  return is_null_sender
 }
 
 /*
@@ -326,8 +334,8 @@ exports.bounce_spf = async function (next, connection) {
 
   const { transaction } = connection
 
-  // Recurse through all textual parts and store all parsed IPs
-  // in a Set to remove any duplicates which might appear.
+  // Recurse through all textual parts of the body and store all parsed
+  // IPs in a Set to remove any duplicates which might appear.
   const ips = this.find_received_headers(transaction.body)
   if (ips.size === 0) {
     connection.loginfo(this, 'No received headers found in message')
@@ -343,18 +351,7 @@ exports.bounce_spf = async function (next, connection) {
   const spf = new SPF()
 
   for (const ip of ips) {
-    let result
-    try {
-      result = await spf.check_host(ip, transaction.rcpt_to[0].host, transaction.rcpt_to[0].address())
-    } catch (err) {
-      connection.logerror(this, err.message)
-      transaction.results.add(this, {
-        skip: 'bounce_spf',
-        msg: err.message,
-      })
-      return next()
-    }
-
+    const result = await spf.check_host(ip, transaction.rcpt_to[0].host, transaction.rcpt_to[0].address())
     const spf_result = spf.result(result)
     connection.logdebug(this, { ip, result, spf_result })
 
@@ -424,7 +421,7 @@ exports.create_validation_hash = function (next, connection) {
 
   const { transaction } = connection
 
-  if (!connection.relaying || this.has_null_sender(transaction)) {
+  if (!connection.relaying || transaction.results.has(this, 'isa', 'yes')) {
     return next()
   }
 
@@ -470,7 +467,6 @@ exports.create_validation_hash = function (next, connection) {
  * Configuration options:
  * - check.hash_validation (boolean): Enable hash-based validation
  * - reject.hash_validation (boolean): Reject bounces that fail hash validation
- * - reject.hash_date (boolean): Reject bounces with expired or invalid dates
  * - skip.remaining_plugins (boolean): Skip remaining plugins if validation passes
  * - validation.max_hash_age_days (number): Maximum age in days for bounce messages
  *
@@ -494,7 +490,8 @@ exports.validate_bounce = function (next, connection) {
 
   const { transaction } = connection
 
-  const { from, date, message_id, hash } = this.find_bounce_headers(transaction, transaction.body)
+  // check message body for headers from the original email
+  const { from, date, message_id, hash } = this.find_bounce_headers(transaction.body)
 
   if (hash) {
     const amalgam = `${from}:${date}:${message_id}`
@@ -524,10 +521,8 @@ exports.validate_bounce = function (next, connection) {
             msg: result.msg,
             emit: true,
           })
-          if (this.cfg.reject.hash_date) {
-            return next(DENY, 'invalid bounce')
-          }
-          return next()
+
+          return next(DENY, 'invalid bounce')
         }
       }
 
@@ -535,17 +530,16 @@ exports.validate_bounce = function (next, connection) {
     } else {
       msg = 'missing headers'
     }
-    if (msg) {
-      transaction.results.add(this, {
-        fail: 'validate_bounce',
-        msg: msg,
-        emit: true,
-      })
-      if (this.cfg.reject.hash_validation) {
-        return next(DENY, 'invalid bounce')
-      }
-      return next()
+
+    transaction.results.add(this, {
+      fail: 'validate_bounce',
+      msg: msg,
+      emit: true,
+    })
+    if (this.cfg.reject.hash_validation) {
+      return next(DENY, 'invalid bounce')
     }
+    return next()
   } else if (from && date && message_id) {
     const from_header = transaction.header.get_decoded('From').toLowerCase()
     let parsed_from
@@ -633,10 +627,10 @@ exports.find_bounce_headers = function (body) {
 
   // Check the current body part
   if (body?.bodytext?.length) {
-    headers.from = extract_header(body.bodytext, 'From')
-    headers.date = extract_header(body.bodytext, 'Date')
-    headers.message_id = extract_header(body.bodytext, 'Message-ID')
-    headers.hash = extract_header(body.bodytext, 'X-Haraka-Bounce-Validation')
+    headers.from = this.extract_header(body.bodytext, 'From')
+    headers.date = this.extract_header(body.bodytext, 'Date')
+    headers.message_id = this.extract_header(body.bodytext, 'Message-ID')
+    headers.hash = this.extract_header(body.bodytext, 'X-Haraka-Bounce-Validation')
 
     // were any headers found?
     if (headers.from || headers.date || headers.message_id || headers.hash) {
@@ -649,7 +643,7 @@ exports.find_bounce_headers = function (body) {
     for (const child of body.children) {
       const child_hdrs = this.find_bounce_headers(child)
 
-      // were any headers found?
+      // Only return if any useful headers were found
       if (child_hdrs.from || child_hdrs.date || child_hdrs.message_id || child_hdrs.hash) {
         return child_hdrs
       }
@@ -662,34 +656,28 @@ exports.find_bounce_headers = function (body) {
 // Determines whether validation checks should be skipped
 // Skips checks for outbound emails or messages that aren't bounces
 exports.should_skip = function (connection) {
-  const not_a_bounce = !this.has_null_sender(connection.transaction)
+  const not_a_bounce = connection.transaction.results.has(this, 'isa', 'no')
 
   return connection.relaying || not_a_bounce
 }
 
 // Extracts a header value from email body text
-function extract_header(bodytext, header_name) {
+exports.extract_header = function (bodytext, header_name) {
   if (!bodytext || typeof bodytext !== 'string') return
 
-  // Use a regular expression with named capture group for the header value
-  const header_re = new RegExp(
-    `^${header_name}:(?<value>[^\r\n]*(?:[\r\n]+[ \t][^\r\n]*)*?)[\r\n]+(?:[a-z\\-]+:|$)`,
-    'imu',
-  )
+  // Match header and any folded continuation lines
+  const regex = new RegExp(`^${header_name}:\\s*(?<value>.+(?:\\r?\\n[ \\t].+)*)`, 'imu')
 
-  const match = header_re.exec(bodytext)
-  if (!match?.groups?.value) return
+  const match = bodytext.match(regex)
 
-  let { value } = match.groups
+  if (!match?.groups) return undefined
 
-  // Split by newlines, remove leading whitespace on folded lines, and join with spaces
-  value = value
-    .split(/[\r\n]+/u)
-    .map((line, i) => (i === 0 ? line : line.replace(/^[ \t]+/u, '')))
-    .join(' ')
-    .trim()
+  // Unfold the header by replacing CRLF/LF followed by whitespace with a single space
+  //  const folded_value = match[1];
+  const folded_value = match.groups.value
+  const unfolded_value = folded_value.replace(/\r?\n[ \t]+/gu, ' ')
 
-  return value
+  return unfolded_value.trim()
 }
 
 exports.is_whitelisted = function (rcpt, from) {

--- a/index.js
+++ b/index.js
@@ -54,24 +54,16 @@ exports.load_bounce_ini = function () {
 }
 
 exports.validate_config = function () {
-  if (!this.cfg.validation.max_hash_age_days) this.cfg.validation.max_hash_age_days = MAX_HASH_AGE_DAYS
-  if (!this.cfg.validation.hash_algorithm) this.cfg.validation.hash_algorithm = 'sha256'
+  const { check, reject } = this.cfg
 
-  // checks needs to be enabled for rejects to work
-  if (this.cfg.reject.single_recipient && !this.cfg.check.single_recipient) {
-    this.cfg.check.single_recipient = true
-  }
-  if (this.cfg.reject.empty_return_path && !this.cfg.check.empty_return_path) {
-    this.cfg.check.empty_return_path = true
-  }
-  if (this.cfg.reject.bounce_spf && !this.cfg.check.bounce_spf) {
-    this.cfg.check.bounce_spf = true
-  }
-  if (this.cfg.reject.hash_validation && !this.cfg.check.hash_validation) {
-    this.cfg.check.hash_validation = true
+  // checks need to be enabled for rejects to work
+  for (const key of ['single_recipient', 'empty_return_path', 'bounce_spf', 'hash_validation']) {
+    if (reject[key] && !check[key]) check[key] = true
   }
 
   if (!this.cfg.check.hash_validation) return
+  if (!this.cfg.validation.max_hash_age_days) this.cfg.validation.max_hash_age_days = MAX_HASH_AGE_DAYS
+  if (!this.cfg.validation.hash_algorithm) this.cfg.validation.hash_algorithm = 'sha256'
 
   // confirm that hash algorithm is supported
   const algorithms = crypto.getHashes()

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "npx eslint *.js test --fix",
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
-    "test": "npx mocha@^11",
+    "test": "npx mocha",
     "test:coverage": "HARAKA_COVERAGE=1 npx c8 npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@haraka/eslint-config": "^2.0.3",
     "haraka-test-fixtures": "^1.3.10",
-    "sinon": "^21.0.2",
+    "sinon": "^21.0.2"
     "c8": "^11.0.0"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@haraka/eslint-config": "^2.0.3",
     "haraka-test-fixtures": "^1.3.10",
     "sinon": "^21.0.2"
-    "c8": "^11.0.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-bounce",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Provide multiple configurable strategies to detect, validate, and process email bounces",
   "main": "index.js",
   "files": [
@@ -13,9 +13,20 @@
     "lint:fix": "npx eslint *.js test --fix",
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
-    "test": "npx mocha",
+    "test": "npx mocha@^11",
+    "test:coverage": "HARAKA_COVERAGE=1 npx c8 npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "c8": {
+    "reporter": [
+      "text",
+      "text-summary",
+      "html"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "devDependencies": {
     "@haraka/eslint-config": "^2.0.3",
     "haraka-test-fixtures": "^1.3.10",
-    "sinon": "^21.0.2"
+    "sinon": "^21.0.2",
+    "c8": "^11.0.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/test/index.js
+++ b/test/index.js
@@ -25,31 +25,6 @@ beforeEach(function () {
 
   this.plugin.register()
 
-  this.plugin.cfg = {
-    validation: {
-      max_hash_age_days: 6,
-      hash_algorithm: 'sha256',
-      secret: crypto.randomBytes(32).toString('base64'),
-    },
-    check: {
-      single_recipient: true,
-      empty_return_path: false,
-      bounce_spf: true,
-      hash_validation: false,
-    },
-    reject: {
-      single_recipient: true,
-      empty_return_path: false,
-      bounce_spf: false,
-      bad_rcpt: true,
-      all_bounces: false,
-      hash_validation: false,
-    },
-    skip: {
-      remaining_plugins: false,
-    },
-  }
-
   this.should_skip_spy = sinon.spy(this.plugin, 'should_skip')
 })
 
@@ -62,7 +37,7 @@ describe('register', function () {
     const load_bounce_whitelist_spy = sinon.spy(this.plugin, 'load_bounce_whitelist')
     const validate_config_spy = sinon.spy(this.plugin, 'validate_config')
 
-    assert.equal('function', typeof this.plugin.register)
+    assert.strictEqual('function', typeof this.plugin.register)
 
     this.plugin.register()
 
@@ -75,16 +50,16 @@ describe('register', function () {
   it('registers hooks', function () {
     assert.ok(this.plugin.register_hook.called)
     let hook_count = 0
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'check_null_sender')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'reject_all')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'bad_rcpt')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'single_recipient')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'bounce_spf_enable')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'empty_return_path')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'create_validation_hash')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'validate_bounce')
-    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'bounce_spf')
-    assert.equal(this.plugin.register_hook.args.length, hook_count)
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'check_null_sender')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'reject_all')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'bad_rcpt')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'single_recipient')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'bounce_spf_enable')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'empty_return_path')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'create_validation_hash')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'validate_bounce')
+    assert.strictEqual(this.plugin.register_hook.args[hook_count++][1], 'bounce_spf')
+    assert.strictEqual(this.plugin.register_hook.args.length, hook_count)
   })
 })
 
@@ -94,8 +69,8 @@ describe('load_configs', function () {
 
     assert.ok(this.plugin.cfg.check)
     assert.ok(this.plugin.cfg.reject)
-    assert.ok(this.plugin.cfg.validation.max_hash_age_days, 6)
-    assert.ok(this.plugin.cfg.validation.hash_algorithm, 'sha256')
+    assert.strictEqual(this.plugin.cfg.validation.max_hash_age_days, 6)
+    assert.strictEqual(this.plugin.cfg.validation.hash_algorithm, 'sha256')
     assert.ok(this.plugin.cfg.skip)
   })
 
@@ -125,7 +100,7 @@ describe('load_configs', function () {
     // Verify all keys and values are lowercased
     assert.deepEqual(this.plugin.cfg.whitelist['test@example.com'], ['no-reply@example.com', 'support@example.com'])
     assert.deepEqual(this.plugin.cfg.whitelist['foo@example.com'], ['*@example.net', 'sales@example.com'])
-    assert.equal(Object.keys(this.plugin.cfg.whitelist).length, 2)
+    assert.strictEqual(Object.keys(this.plugin.cfg.whitelist).length, 2)
   })
 })
 
@@ -133,6 +108,25 @@ describe('validate_config', function () {
   let getHashes_stub, logerror_spy
 
   beforeEach(function () {
+    this.plugin.cfg = {
+      check: {
+        single_recipient: true,
+        empty_return_path: false,
+        bounce_spf: true,
+        hash_validation: true,
+      },
+      reject: {
+        single_recipient: true,
+        empty_return_path: false,
+        bounce_spf: false,
+        hash_validation: false,
+      },
+      validation: {
+        max_hash_age_days: 6,
+        hash_algorithm: 'sha256',
+      },
+    }
+
     logerror_spy = sinon.spy(this.plugin, 'logerror')
     getHashes_stub = sinon.stub(crypto, 'getHashes')
     getHashes_stub.returns(['sha256', 'sha512', 'md5'])
@@ -143,16 +137,14 @@ describe('validate_config', function () {
 
     this.plugin.validate_config()
 
-    assert.ok(getHashes_stub.notCalled)
-    assert.ok(this.plugin.cfg.validation.max_hash_age_days)
+    assert.ok(getHashes_stub.calledOnce)
+    assert.strictEqual(this.plugin.cfg.validation.max_hash_age_days, 6)
   })
 
   it('will enable single recipient check', function () {
-    this.plugin.cfg.check.single_recipient = false
-
     this.plugin.validate_config()
 
-    assert.ok(getHashes_stub.notCalled)
+    assert.ok(getHashes_stub.calledOnce)
     assert.ok(this.plugin.cfg.check.single_recipient)
   })
 
@@ -161,23 +153,22 @@ describe('validate_config', function () {
 
     this.plugin.validate_config()
 
-    assert.ok(getHashes_stub.notCalled)
+    assert.ok(getHashes_stub.calledOnce)
     assert.ok(this.plugin.cfg.check.empty_return_path)
   })
 
   it('will enable bounce SPF check', function () {
-    this.plugin.cfg.check.bounce_spf = false
     this.plugin.cfg.reject.bounce_spf = true
 
     this.plugin.validate_config()
 
-    assert.ok(getHashes_stub.notCalled)
+    assert.ok(getHashes_stub.calledOnce)
     assert.ok(this.plugin.cfg.check.bounce_spf)
   })
 
   it('will enable bounce hash validation', function () {
-    this.plugin.cfg.check.hash_validation = false
     this.plugin.cfg.reject.hash_validation = true
+    this.plugin.cfg.validation.secret = crypto.randomBytes(32).toString('base64')
 
     this.plugin.validate_config()
 
@@ -186,65 +177,58 @@ describe('validate_config', function () {
   })
 
   it('will not check hash validation', function () {
+    this.plugin.cfg.check.hash_validation = false
+
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.notCalled)
-    assert.equal(this.plugin.cfg.check.hash_validation, false)
+    assert.strictEqual(this.plugin.cfg.check.hash_validation, false)
   })
 
   it('has invalid hash algorithm', function () {
-    this.plugin.cfg.check.hash_validation = true
     this.plugin.cfg.validation.hash_algorithm = 'invalid_algorithm'
 
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
-    assert.equal(this.plugin.cfg.check.hash_validation, false)
+    assert.strictEqual(this.plugin.cfg.check.hash_validation, false)
   })
 
   it('is missing hash algorithm', function () {
-    delete this.plugin.cfg.validation.hash_algorithm
-
-    this.plugin.validate_config()
-
-    assert.ok(getHashes_stub.notCalled)
-    assert.equal(this.plugin.cfg.validation.hash_algorithm, 'sha256')
-  })
-
-  it('is missing the secret key', function () {
-    delete this.plugin.cfg.validation.secret
-    this.plugin.cfg.check.hash_validation = true
-
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
-    assert.equal(this.plugin.cfg.check.hash_validation, false)
+    assert.strictEqual(this.plugin.cfg.validation.hash_algorithm, 'sha256')
+  })
+
+  it('is missing the secret key', function () {
+    this.plugin.validate_config()
+
+    assert.ok(getHashes_stub.calledOnce)
+    assert.strictEqual(this.plugin.cfg.check.hash_validation, false)
   })
 
   it('has short secret key', function () {
     this.plugin.cfg.validation.secret = 'short_key'
-    this.plugin.cfg.check.hash_validation = true
 
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
     assert.ok(logerror_spy.calledOnce)
-    assert.equal(this.plugin.cfg.check.hash_validation, false)
+    assert.strictEqual(this.plugin.cfg.check.hash_validation, false)
   })
 
-  it('has default config settings', function () {
-    this.plugin.cfg.check.hash_validation = true
+  it('has default secret', function () {
     this.plugin.cfg.validation.secret = 'your_generated_secret_here'
 
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
     assert.ok(logerror_spy.calledOnce)
-    assert.equal(this.plugin.cfg.check.hash_validation, false)
+    assert.strictEqual(this.plugin.cfg.check.hash_validation, false)
   })
 
-  it('has valid config settings', function () {
-    this.plugin.cfg.check.hash_validation = true
+  it('has valid secret', function () {
     this.plugin.cfg.validation.secret = 'valid_secret_thats_at_least_32_characters_long'
 
     this.plugin.validate_config()
@@ -264,8 +248,8 @@ describe('reject_all', function () {
     await new Promise((resolve) => {
       this.plugin.reject_all((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -276,8 +260,8 @@ describe('reject_all', function () {
 
     await new Promise((resolve) => {
       this.plugin.reject_all((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -289,8 +273,8 @@ describe('reject_all', function () {
     await new Promise((resolve) => {
       this.plugin.reject_all((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -302,8 +286,8 @@ describe('reject_all', function () {
     await new Promise((resolve) => {
       this.plugin.reject_all((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -316,8 +300,8 @@ describe('reject_all', function () {
         assert.ok(this.should_skip_spy.returned(false))
         this.connection.transaction.results.has(this.plugin, 'fail', 'bounces_accepted')
         this.connection.transaction.results.has(this.plugin, 'msg', 'bounces not accepted here')
-        assert.equal(code, DENY)
-        assert.equal(msg, 'Bounces not accepted here')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'Bounces not accepted here')
         resolve()
       }, this.connection)
     })
@@ -336,8 +320,8 @@ describe('empty_return_path', function () {
     await new Promise((resolve) => {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -349,8 +333,8 @@ describe('empty_return_path', function () {
     await new Promise((resolve) => {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -362,8 +346,8 @@ describe('empty_return_path', function () {
     await new Promise((resolve) => {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -374,8 +358,8 @@ describe('empty_return_path', function () {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'empty_return_path'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -387,8 +371,8 @@ describe('empty_return_path', function () {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'empty_return_path'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -400,8 +384,8 @@ describe('empty_return_path', function () {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'empty_return_path'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -417,8 +401,8 @@ describe('empty_return_path', function () {
         assert.ok(this.should_skip_spy.returned(false))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'empty_return_path'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'bounce with non-empty Return-Path'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -432,8 +416,8 @@ describe('empty_return_path', function () {
         assert.ok(this.should_skip_spy.returned(false))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'empty_return_path'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'bounce with non-empty Return-Path'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'bounce with non-empty Return-Path (RFC 3834)')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'bounce with non-empty Return-Path (RFC 3834)')
         resolve()
       }, this.connection)
     })
@@ -446,8 +430,8 @@ describe('single_recipient', function () {
 
     await new Promise((resolve) => {
       this.plugin.single_recipient((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -458,8 +442,8 @@ describe('single_recipient', function () {
     await new Promise((resolve) => {
       this.plugin.single_recipient((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -471,8 +455,8 @@ describe('single_recipient', function () {
     await new Promise((resolve) => {
       this.plugin.single_recipient((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -483,8 +467,8 @@ describe('single_recipient', function () {
       this.plugin.single_recipient((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'single_recipient'))
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -497,8 +481,8 @@ describe('single_recipient', function () {
       this.plugin.single_recipient((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'single_recipient'))
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -511,8 +495,8 @@ describe('single_recipient', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'single_recipient'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'too many recipients'))
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.equal(code, DENY)
-        assert.equal(msg, 'this bounce message has too many recipients')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'this bounce message has too many recipients')
         resolve()
       }, this.connection)
     })
@@ -532,8 +516,8 @@ describe('bad_rcpt', function () {
       this.plugin.bad_rcpt(
         (code, msg) => {
           assert.ok(this.should_skip_spy.notCalled)
-          assert.equal(code, undefined)
-          assert.equal(msg, undefined)
+          assert.strictEqual(code, undefined)
+          assert.strictEqual(msg, undefined)
           resolve()
         },
         this.connection,
@@ -548,8 +532,8 @@ describe('bad_rcpt', function () {
     await new Promise((resolve) => {
       this.plugin.bad_rcpt((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -561,8 +545,8 @@ describe('bad_rcpt', function () {
     await new Promise((resolve) => {
       this.plugin.bad_rcpt((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -575,8 +559,8 @@ describe('bad_rcpt', function () {
       (code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bad_rcpt'))
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
       },
       this.connection,
       rcpt,
@@ -591,8 +575,8 @@ describe('bad_rcpt', function () {
           assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bad_rcpt'))
           assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'rcpt does not accept bounces'))
           assert.ok(this.should_skip_spy.calledOnce)
-          assert.equal(code, DENY)
-          assert.equal(msg, `${rcpt.address()} does not accept bounces`)
+          assert.strictEqual(code, DENY)
+          assert.strictEqual(msg, `${rcpt.address()} does not accept bounces`)
           resolve()
         },
         this.connection,
@@ -609,8 +593,8 @@ describe('bounce_spf_enable', function () {
     await new Promise((resolve) => {
       this.plugin.bounce_spf_enable((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -621,9 +605,9 @@ describe('bounce_spf_enable', function () {
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf_enable((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
-        assert.equal(this.connection.transaction.parse_body, false)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
+        assert.strictEqual(this.connection.transaction.parse_body, false)
         resolve()
       }, this.connection)
     })
@@ -636,9 +620,9 @@ describe('bounce_spf_enable', function () {
     await new Promise((resolve) => {
       this.plugin.bounce_spf_enable((code, msg) => {
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
-        assert.equal(this.connection.transaction.parse_body, true)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
+        assert.strictEqual(this.connection.transaction.parse_body, true)
         resolve()
       }, this.connection)
     })
@@ -673,8 +657,8 @@ describe('bounce_spf', function () {
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -686,8 +670,8 @@ describe('bounce_spf', function () {
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -700,8 +684,8 @@ describe('bounce_spf', function () {
       this.plugin.bounce_spf((code, msg) => {
         assert.ok(this.should_skip_spy.calledOnce)
         assert.ok(find_received_headers_stub.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -716,8 +700,8 @@ describe('bounce_spf', function () {
         assert.ok(this.should_skip_spy.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'no'))
         assert.ok(find_received_headers_stub.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -732,8 +716,8 @@ describe('bounce_spf', function () {
       this.plugin.bounce_spf((code, msg) => {
         assert.ok(this.should_skip_spy.calledOnce)
         assert.ok(find_received_headers_stub.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -751,8 +735,8 @@ describe('bounce_spf', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'no IP addresses found in message'))
         assert.ok(spf_check_host_stub.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -772,8 +756,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledTwice)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bounce_spf'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -788,8 +772,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned TempError'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -804,8 +788,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned PermError'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -820,8 +804,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned None'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -835,8 +819,8 @@ describe('bounce_spf', function () {
       this.plugin.bounce_spf((code, msg) => {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bounce_spf'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -851,8 +835,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'Invalid bounce (spoofed sender)')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'Invalid bounce (spoofed sender)')
         resolve()
       }, this.connection)
     })
@@ -867,8 +851,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'Invalid bounce (spoofed sender)')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'Invalid bounce (spoofed sender)')
         resolve()
       }, this.connection)
     })
@@ -885,8 +869,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -901,8 +885,8 @@ describe('bounce_spf', function () {
         assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'Invalid bounce (spoofed sender)')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'Invalid bounce (spoofed sender)')
         resolve()
       }, this.connection)
     })
@@ -930,8 +914,8 @@ describe('create_validation_hash', function () {
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -943,8 +927,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.notCalled(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -956,8 +940,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.notCalled(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -971,8 +955,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.notCalled(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -988,8 +972,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.calledThrice(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -999,8 +983,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.calledThrice(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1011,6 +995,8 @@ describe('create_validation_hash', function () {
     const from_header = '<test@example.com>'
     const message_id = '<test@example.COM>'
 
+    this.plugin.cfg.validation.secret = crypto.randomBytes(32).toString('base64')
+
     this.connection.transaction.add_header('From', from_header)
     this.connection.transaction.add_header('Date', date_header)
     this.connection.transaction.add_header('Message-ID', message_id)
@@ -1018,8 +1004,8 @@ describe('create_validation_hash', function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
         sinon.assert.calledThrice(get_decoded_spy)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1034,6 +1020,7 @@ describe('validate_bounce', function () {
   beforeEach(function () {
     this.plugin.cfg.check.hash_validation = true
     this.plugin.cfg.reject.hash_validation = true
+    this.plugin.cfg.validation.secret = crypto.randomBytes(32).toString('base64')
 
     this.plugin.cfg.whitelist = {}
 
@@ -1060,8 +1047,8 @@ describe('validate_bounce', function () {
 
     await new Promise((resolve) => {
       this.plugin.validate_bounce((code, msg) => {
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1073,8 +1060,8 @@ describe('validate_bounce', function () {
     await new Promise((resolve) => {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1086,8 +1073,8 @@ describe('validate_bounce', function () {
     await new Promise((resolve) => {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.should_skip_spy.returned(true))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1107,8 +1094,8 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash length mismatch'))
         assert(find_bounce_headers_stub.calledOnce)
         assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1126,8 +1113,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash length mismatch'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1143,8 +1130,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash length mismatch'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1159,8 +1146,8 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'validate_bounce'))
         assert(find_bounce_headers_stub.calledOnce)
         assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1176,8 +1163,8 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'validate_bounce'))
         assert(find_bounce_headers_stub.calledOnce)
         assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
-        assert.equal(code, OK)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, OK)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1198,8 +1185,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash does not match'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1218,8 +1205,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash does not match'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1236,8 +1223,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1254,8 +1241,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1272,8 +1259,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1288,8 +1275,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1304,8 +1291,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1320,8 +1307,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing headers'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1343,8 +1330,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid from header'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1367,8 +1354,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'whitelisted'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1391,8 +1378,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'whitelisted'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1410,8 +1397,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid from header'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
 
         resolve()
       }, this.connection)
@@ -1431,8 +1418,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing validation hash'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1450,8 +1437,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing validation hash'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1465,8 +1452,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing all headers'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.strictEqual(code, undefined)
+        assert.strictEqual(msg, undefined)
         resolve()
       }, this.connection)
     })
@@ -1485,8 +1472,8 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash is too old'))
         assert(find_bounce_headers_stub.calledOnce)
         assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1502,8 +1489,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_date'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid date header'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1519,8 +1506,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_date'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid date header'))
-        assert.equal(code, DENY)
-        assert.equal(msg, 'invalid bounce')
+        assert.strictEqual(code, DENY)
+        assert.strictEqual(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1540,15 +1527,15 @@ describe('is_date_valid', function () {
     const SevenDaysAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 7)
     const date_header = SevenDaysAgo.toUTCString()
     const result = this.plugin.is_date_valid(date_header)
-    assert.equal(result.valid, false)
-    assert.equal(result.msg, 'hash is too old')
+    assert.strictEqual(result.valid, false)
+    assert.strictEqual(result.msg, 'hash is too old')
   })
 
   it('has invalid date', function () {
     const not_a_date = 'hello world'
     const result = this.plugin.is_date_valid(not_a_date)
-    assert.equal(result.valid, false)
-    assert.equal(result.msg, 'invalid date header')
+    assert.strictEqual(result.valid, false)
+    assert.strictEqual(result.msg, 'invalid date header')
   })
 })
 
@@ -1558,7 +1545,7 @@ describe('is_whitelisted', function () {
 
     const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
 
-    assert.equal(whitelisted, false)
+    assert.strictEqual(whitelisted, false)
   })
 
   it('is whitelisted with an exact match', function () {
@@ -1606,16 +1593,16 @@ Message-ID: ${message_id}
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(JSON.stringify(headers), '{}')
+    assert.strictEqual(JSON.stringify(headers), '{}')
   })
 
   it('has all headers in body', function () {
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from)
-    assert.equal(headers.date, date)
-    assert.equal(headers.message_id, message_id)
-    assert.equal(headers.hash, hash)
+    assert.strictEqual(headers.from, from)
+    assert.strictEqual(headers.date, date)
+    assert.strictEqual(headers.message_id, message_id)
+    assert.strictEqual(headers.hash, hash)
   })
 
   it('has From header in body', function () {
@@ -1624,10 +1611,10 @@ Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from)
-    assert.equal(headers.date, undefined)
-    assert.equal(headers.message_id, undefined)
-    assert.equal(headers.hash, undefined)
+    assert.strictEqual(headers.from, from)
+    assert.strictEqual(headers.date, undefined)
+    assert.strictEqual(headers.message_id, undefined)
+    assert.strictEqual(headers.hash, undefined)
   })
 
   it('has Date header in body', function () {
@@ -1635,10 +1622,10 @@ Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, undefined)
-    assert.equal(headers.date, date)
-    assert.equal(headers.message_id, undefined)
-    assert.equal(headers.hash, undefined)
+    assert.strictEqual(headers.from, undefined)
+    assert.strictEqual(headers.date, date)
+    assert.strictEqual(headers.message_id, undefined)
+    assert.strictEqual(headers.hash, undefined)
   })
 
   it('has no headers in body', function () {
@@ -1646,10 +1633,10 @@ Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, undefined)
-    assert.equal(headers.date, undefined)
-    assert.equal(headers.message_id, undefined)
-    assert.equal(headers.hash, undefined)
+    assert.strictEqual(headers.from, undefined)
+    assert.strictEqual(headers.date, undefined)
+    assert.strictEqual(headers.message_id, undefined)
+    assert.strictEqual(headers.hash, undefined)
   })
 
   it('has headers in body.children', function () {
@@ -1660,10 +1647,10 @@ Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from)
-    assert.equal(headers.date, date)
-    assert.equal(headers.message_id, message_id)
-    assert.equal(headers.hash, hash)
+    assert.strictEqual(headers.from, from)
+    assert.strictEqual(headers.date, date)
+    assert.strictEqual(headers.message_id, message_id)
+    assert.strictEqual(headers.hash, hash)
   })
 
   it('has no headers in body.children', function () {
@@ -1674,10 +1661,10 @@ Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, undefined)
-    assert.equal(headers.date, undefined)
-    assert.equal(headers.message_id, undefined)
-    assert.equal(headers.hash, undefined)
+    assert.strictEqual(headers.from, undefined)
+    assert.strictEqual(headers.date, undefined)
+    assert.strictEqual(headers.message_id, undefined)
+    assert.strictEqual(headers.hash, undefined)
   })
 
   it('has folded headers', function () {
@@ -1691,10 +1678,10 @@ X-Haraka-Bounce-Validation: ${hash}
 `
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, unfolded_from)
-    assert.equal(headers.date, date)
-    assert.equal(headers.message_id, message_id)
-    assert.equal(headers.hash, hash)
+    assert.strictEqual(headers.from, unfolded_from)
+    assert.strictEqual(headers.date, date)
+    assert.strictEqual(headers.message_id, message_id)
+    assert.strictEqual(headers.hash, hash)
   })
 })
 
@@ -1706,7 +1693,7 @@ describe('should_skip', function () {
 
     const result = this.plugin.should_skip(this.connection)
 
-    assert.equal(result, true)
+    assert.strictEqual(result, true)
   })
 
   it('is relaying and is a bounce', function () {
@@ -1715,7 +1702,7 @@ describe('should_skip', function () {
 
     const result = this.plugin.should_skip(this.connection)
 
-    assert.equal(result, true)
+    assert.strictEqual(result, true)
   })
 
   it('is not relaying and is not a bounce', function () {
@@ -1725,7 +1712,7 @@ describe('should_skip', function () {
 
     const result = this.plugin.should_skip(this.connection)
 
-    assert.equal(result, true)
+    assert.strictEqual(result, true)
   })
 
   it('is not relaying and is a bounce', function () {
@@ -1734,7 +1721,7 @@ describe('should_skip', function () {
 
     const result = this.plugin.should_skip(this.connection)
 
-    assert.equal(result, false)
+    assert.strictEqual(result, false)
   })
 })
 
@@ -1746,13 +1733,13 @@ describe('find_received_headers', function () {
   it('has no body', function () {
     const ips = this.plugin.find_received_headers('')
 
-    assert.equal(ips.size, 0)
+    assert.strictEqual(ips.size, 0)
   })
 
   it('has no Received headers', function () {
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 0)
+    assert.strictEqual(ips.size, 0)
   })
 
   it('has one Received header', function () {
@@ -1762,7 +1749,7 @@ describe('find_received_headers', function () {
 
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 1)
+    assert.strictEqual(ips.size, 1)
     assert.ok(ips.has(ip))
   })
 
@@ -1777,7 +1764,7 @@ Received: from mail.example.com (HELO mail.example.com) (${ip2})
 
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 1)
+    assert.strictEqual(ips.size, 1)
     assert.ok(ips.has(ip2))
   })
 
@@ -1792,7 +1779,7 @@ Received: from mail.example.com (mail.example.com [${ip2}])
 
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 2)
+    assert.strictEqual(ips.size, 2)
     assert.ok(ips.has(ip1))
     assert.ok(ips.has(ip2))
   })
@@ -1810,7 +1797,7 @@ Received: from prod.example.com
 
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 2)
+    assert.strictEqual(ips.size, 2)
     assert.ok(ips.has(ip1))
     assert.ok(ips.has(ip2))
   })
@@ -1828,7 +1815,7 @@ Received: from mail.example.com (mail.example.com [${ip2}])
     }
     const ips = this.plugin.find_received_headers(this.connection.transaction.body)
 
-    assert.equal(ips.size, 2)
+    assert.strictEqual(ips.size, 2)
     assert.ok(ips.has(ip1))
     assert.ok(ips.has(ip2))
   })
@@ -1912,17 +1899,17 @@ describe('check_null_sender', function () {
   it('is relaying', function () {
     this.connection.relaying = true
     this.plugin.check_null_sender((code, msg) => {
-      assert.strictEqual(this.connection.transaction.results.get(this.plugin), undefined)
-      assert.equal(code, undefined)
-      assert.equal(msg, undefined)
+      assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
+      assert.strictEqual(code, undefined)
+      assert.strictEqual(msg, undefined)
     }, this.connection)
   })
 
   it('has null sender', function () {
     this.plugin.check_null_sender((code, msg) => {
       assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
-      assert.equal(code, undefined)
-      assert.equal(msg, undefined)
+      assert.strictEqual(code, undefined)
+      assert.strictEqual(msg, undefined)
     }, this.connection)
   })
 
@@ -1931,8 +1918,8 @@ describe('check_null_sender', function () {
 
     this.plugin.check_null_sender((code, msg) => {
       assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
-      assert.equal(code, undefined)
-      assert.equal(msg, undefined)
+      assert.strictEqual(code, undefined)
+      assert.strictEqual(msg, undefined)
     }, this.connection)
   })
 
@@ -1941,13 +1928,15 @@ describe('check_null_sender', function () {
 
     this.plugin.check_null_sender((code, msg) => {
       assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'no'))
-      assert.equal(code, undefined)
-      assert.equal(msg, undefined)
+      assert.strictEqual(code, undefined)
+      assert.strictEqual(msg, undefined)
     }, this.connection)
   })
 })
 
 function create_headers(plugin, options = {}) {
+  plugin.cfg.validation.secret = crypto.randomBytes(32).toString('base64')
+
   const date_header = options.date_header || new Date().toISOString()
   const from_header = options.from_header || 'test <test@example.com>'
   const message_id = options.message_id || '<PB8-DCB-KHNZ4Y5J3N0Z@example.com>'

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,6 @@ beforeEach(function () {
   this.connection.remote.ip = '8.8.8.8'
   this.connection.relaying = false
   this.connection.init_transaction()
-  this.connection.transaction.results = new fixtures.result_store(this.connection)
   this.connection.transaction.mail_from = new Address.Address('<>')
   this.connection.transaction.rcpt_to.push(new Address.Address('test@example.com'))
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,14 +9,47 @@ const fixtures = require('haraka-test-fixtures')
 
 beforeEach(function () {
   this.plugin = new fixtures.plugin('bounce')
+
+  // replace vm-compiled functions with instrumented versions for coverage tracking
+  if (process.env.HARAKA_COVERAGE) {
+    const plugin_module = require('../index.js')
+    Object.assign(this.plugin, plugin_module)
+  }
+
   this.connection = fixtures.connection.createConnection()
   this.connection.remote.ip = '8.8.8.8'
   this.connection.relaying = false
   this.connection.init_transaction()
+  this.connection.transaction.results = new fixtures.result_store(this.connection)
   this.connection.transaction.mail_from = new Address.Address('<>')
   this.connection.transaction.rcpt_to.push(new Address.Address('test@example.com'))
 
   this.plugin.register()
+
+  this.plugin.cfg = {
+    validation: {
+      max_hash_age_days: 6,
+      hash_algorithm: 'sha256',
+      secret: crypto.randomBytes(32).toString('base64'),
+    },
+    check: {
+      single_recipient: true,
+      empty_return_path: false,
+      bounce_spf: true,
+      hash_validation: false,
+    },
+    reject: {
+      single_recipient: true,
+      empty_return_path: false,
+      bounce_spf: false,
+      bad_rcpt: true,
+      all_bounces: false,
+      hash_validation: false,
+    },
+    skip: {
+      remaining_plugins: false,
+    },
+  }
 
   this.should_skip_spy = sinon.spy(this.plugin, 'should_skip')
 })
@@ -25,22 +58,25 @@ afterEach(sinon.restore)
 
 describe('register', function () {
   it('should have register function', function () {
-    const load_bounce_ini_stub = sinon.stub(this.plugin, 'load_bounce_ini')
-    const load_bounce_bad_rcpt_stub = sinon.stub(this.plugin, 'load_bounce_bad_rcpt')
-    const load_bounce_whitelist_stub = sinon.stub(this.plugin, 'load_bounce_whitelist')
+    const load_bounce_ini_spy = sinon.spy(this.plugin, 'load_bounce_ini')
+    const load_bounce_bad_rcpt_spy = sinon.spy(this.plugin, 'load_bounce_bad_rcpt')
+    const load_bounce_whitelist_spy = sinon.spy(this.plugin, 'load_bounce_whitelist')
+    const validate_config_spy = sinon.spy(this.plugin, 'validate_config')
 
     assert.equal('function', typeof this.plugin.register)
 
     this.plugin.register()
 
-    assert.ok(load_bounce_ini_stub.calledOnce)
-    assert.ok(load_bounce_bad_rcpt_stub.calledOnce)
-    assert.ok(load_bounce_whitelist_stub.calledOnce)
+    assert.ok(load_bounce_ini_spy.calledOnce)
+    assert.ok(load_bounce_bad_rcpt_spy.calledOnce)
+    assert.ok(load_bounce_whitelist_spy.calledOnce)
+    assert.ok(validate_config_spy.calledOnce)
   })
 
   it('registers hooks', function () {
     assert.ok(this.plugin.register_hook.called)
     let hook_count = 0
+    assert.equal(this.plugin.register_hook.args[hook_count++][1], 'check_null_sender')
     assert.equal(this.plugin.register_hook.args[hook_count++][1], 'reject_all')
     assert.equal(this.plugin.register_hook.args[hook_count++][1], 'bad_rcpt')
     assert.equal(this.plugin.register_hook.args[hook_count++][1], 'single_recipient')
@@ -55,63 +91,61 @@ describe('register', function () {
 
 describe('load_configs', function () {
   it('load_bounce_ini', function () {
-    const validate_config_stub = sinon.stub(this.plugin, 'validate_config')
-
     this.plugin.load_bounce_ini()
 
-    assert.ok(validate_config_stub.calledOnce)
     assert.ok(this.plugin.cfg.check)
     assert.ok(this.plugin.cfg.reject)
-    assert.ok(this.plugin.cfg.validation)
+    assert.ok(this.plugin.cfg.validation.max_hash_age_days, 6)
+    assert.ok(this.plugin.cfg.validation.hash_algorithm, 'sha256')
+    assert.ok(this.plugin.cfg.skip)
   })
 
   it('load_bounce_bad_rcpt', function () {
-    const load_bounce_bad_rcpt_stub = sinon.stub(this.plugin, 'load_bounce_bad_rcpt')
+    const config_get_stub = sinon.stub(this.plugin.config, 'get')
+    config_get_stub.returns(['Test1@Example.com', 'TEST2@example.COM'])
 
     this.plugin.load_bounce_bad_rcpt()
 
-    assert.ok(load_bounce_bad_rcpt_stub.calledOnce)
-    assert.ok(this.plugin.cfg.invalid_addrs)
+    assert.ok(config_get_stub.calledWith('bounce_bad_rcpt', 'list'))
+    // Verify addresses are lowercased
+    assert.deepEqual(this.plugin.cfg.invalid_addrs, ['test1@example.com', 'test2@example.com'])
   })
 
   it('load_bounce_whitelist', function () {
-    const load_bounce_whitelist_stub = sinon.stub(this.plugin, 'load_bounce_whitelist')
+    const config_get_stub = sinon.stub(this.plugin.config, 'get')
+    // Stub config.get() to return whitelist with mixed-case keys and values
+    config_get_stub.returns({
+      'Test@Example.com': ['No-Reply@Example.com', 'Support@Example.COM'],
+      'FOO@Example.com': ['*@Example.NET', 'Sales@example.com'],
+    })
 
     this.plugin.load_bounce_whitelist()
 
-    assert.ok(load_bounce_whitelist_stub.calledOnce)
-    assert.ok(this.plugin.cfg.whitelist)
+    assert.ok(config_get_stub.calledWith('bounce_whitelist.json'))
+
+    // Verify all keys and values are lowercased
+    assert.deepEqual(this.plugin.cfg.whitelist['test@example.com'], ['no-reply@example.com', 'support@example.com'])
+    assert.deepEqual(this.plugin.cfg.whitelist['foo@example.com'], ['*@example.net', 'sales@example.com'])
+    assert.equal(Object.keys(this.plugin.cfg.whitelist).length, 2)
   })
 })
 
 describe('validate_config', function () {
-  let getHashes_stub, logerror_stub
+  let getHashes_stub, logerror_spy
 
   beforeEach(function () {
-    this.plugin.cfg = {
-      validation: {
-        max_hash_age_days: 6,
-        hash_algorithm: 'sha256',
-        secret: crypto.randomBytes(32).toString('base64'),
-      },
-      check: {
-        single_recipient: true,
-        empty_return_path: false,
-        bounce_spf: true,
-        hash_validation: false,
-        hash_date: true,
-      },
-      reject: {
-        single_recipient: true,
-        empty_return_path: false,
-        bounce_spf: false,
-        hash_validation: false,
-        hash_date: false,
-      },
-    }
-    logerror_stub = sinon.stub(this.plugin, 'logerror')
+    logerror_spy = sinon.spy(this.plugin, 'logerror')
     getHashes_stub = sinon.stub(crypto, 'getHashes')
     getHashes_stub.returns(['sha256', 'sha512', 'md5'])
+  })
+
+  it('will set default max hash age', function () {
+    delete this.plugin.cfg.validation.max_hash_age_days
+
+    this.plugin.validate_config()
+
+    assert.ok(getHashes_stub.notCalled)
+    assert.ok(this.plugin.cfg.validation.max_hash_age_days)
   })
 
   it('will enable single recipient check', function () {
@@ -142,15 +176,14 @@ describe('validate_config', function () {
     assert.ok(this.plugin.cfg.check.bounce_spf)
   })
 
-  it('will enable hash date check', function () {
-    this.plugin.cfg.check.hash_validation = true
-    this.plugin.cfg.check.hash_date = false
-    this.plugin.cfg.reject.hash_date = true
+  it('will enable bounce hash validation', function () {
+    this.plugin.cfg.check.hash_validation = false
+    this.plugin.cfg.reject.hash_validation = true
 
     this.plugin.validate_config()
 
+    assert.ok(this.plugin.cfg.check.hash_validation)
     assert.ok(getHashes_stub.calledOnce)
-    assert.ok(this.plugin.cfg.check.hash_date)
   })
 
   it('will not check hash validation', function () {
@@ -170,6 +203,15 @@ describe('validate_config', function () {
     assert.equal(this.plugin.cfg.check.hash_validation, false)
   })
 
+  it('is missing hash algorithm', function () {
+    delete this.plugin.cfg.validation.hash_algorithm
+
+    this.plugin.validate_config()
+
+    assert.ok(getHashes_stub.notCalled)
+    assert.equal(this.plugin.cfg.validation.hash_algorithm, 'sha256')
+  })
+
   it('is missing the secret key', function () {
     delete this.plugin.cfg.validation.secret
     this.plugin.cfg.check.hash_validation = true
@@ -187,7 +229,7 @@ describe('validate_config', function () {
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
-    assert.ok(logerror_stub.calledOnce)
+    assert.ok(logerror_spy.calledOnce)
     assert.equal(this.plugin.cfg.check.hash_validation, false)
   })
 
@@ -198,7 +240,7 @@ describe('validate_config', function () {
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
-    assert.ok(logerror_stub.calledOnce)
+    assert.ok(logerror_spy.calledOnce)
     assert.equal(this.plugin.cfg.check.hash_validation, false)
   })
 
@@ -209,7 +251,7 @@ describe('validate_config', function () {
     this.plugin.validate_config()
 
     assert.ok(getHashes_stub.calledOnce)
-    assert.ok(logerror_stub.notCalled)
+    assert.ok(logerror_spy.notCalled)
   })
 })
 
@@ -234,7 +276,7 @@ describe('reject_all', function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.reject_all((code, msg) => {
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -256,6 +298,7 @@ describe('reject_all', function () {
   })
 
   it('will ignore non-bounce mail', async function () {
+    this.connection.transaction.results.add(this.plugin, { isa: 'no' })
     this.connection.transaction.mail_from = new Address.Address('<test@example.com>')
     await new Promise((resolve) => {
       this.plugin.reject_all((code, msg) => {
@@ -269,6 +312,7 @@ describe('reject_all', function () {
 
   it('will reject all bounces', async function () {
     await new Promise((resolve) => {
+      this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
       this.plugin.reject_all((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
         this.connection.transaction.results.has(this.plugin, 'fail', 'bounces_accepted')
@@ -313,7 +357,20 @@ describe('empty_return_path', function () {
     })
   })
 
-  it('missing Return-Path header', async function () {
+  it('will ignore outbound mail', async function () {
+    this.connection.relaying = true
+
+    await new Promise((resolve) => {
+      this.plugin.empty_return_path((code, msg) => {
+        assert.ok(this.should_skip_spy.returned(true))
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
+  it('has missing Return-Path header', async function () {
     await new Promise((resolve) => {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
@@ -327,6 +384,19 @@ describe('empty_return_path', function () {
 
   it('has empty Return-Path header', async function () {
     this.connection.transaction.add_header('Return-Path', '')
+    await new Promise((resolve) => {
+      this.plugin.empty_return_path((code, msg) => {
+        assert.ok(this.should_skip_spy.returned(false))
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'empty_return_path'))
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
+  it('has empty return path in Return-Path header', async function () {
+    this.connection.transaction.add_header('Return-Path', '<>')
     await new Promise((resolve) => {
       this.plugin.empty_return_path((code, msg) => {
         assert.ok(this.should_skip_spy.returned(false))
@@ -376,7 +446,7 @@ describe('single_recipient', function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.single_recipient((code, msg) => {
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -389,6 +459,19 @@ describe('single_recipient', function () {
     await new Promise((resolve) => {
       this.plugin.single_recipient((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
+  it('will ignore outbound mail', async function () {
+    this.connection.relaying = true
+
+    await new Promise((resolve) => {
+      this.plugin.single_recipient((code, msg) => {
+        assert.ok(this.should_skip_spy.returned(true))
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -439,14 +522,15 @@ describe('single_recipient', function () {
 
 describe('bad_rcpt', function () {
   beforeEach(function () {
-    this.plugin.cfg.invalid_addrs = ['bad1@example.com', 'bad2@example.com']
+    const raw_list = ['bad1@example.com', 'BAD2@example.com']
+    this.plugin.cfg.invalid_addrs = raw_list.map((n) => n.toLowerCase())
   })
 
   it('will not check for bad recipient', async function () {
     this.plugin.cfg.reject.bad_rcpt = false
 
     await new Promise((resolve) => {
-      this.plugin.reject_all(
+      this.plugin.bad_rcpt(
         (code, msg) => {
           assert.ok(this.should_skip_spy.notCalled)
           assert.equal(code, undefined)
@@ -463,7 +547,7 @@ describe('bad_rcpt', function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.bad_rcpt((code, msg) => {
         assert.ok(this.should_skip_spy.notCalled)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
@@ -472,22 +556,32 @@ describe('bad_rcpt', function () {
     })
   })
 
-  it('will check for valid recipient', async function () {
+  it('will ignore outbound mail', async function () {
+    this.connection.relaying = true
+
+    await new Promise((resolve) => {
+      this.plugin.bad_rcpt((code, msg) => {
+        assert.ok(this.should_skip_spy.returned(true))
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
+  it('will verify recipient allows bounces', function () {
     this.plugin.cfg.invalid_addrs = []
     const rcpt = new Address.Address('test@example.com')
-    await new Promise((resolve) => {
-      this.plugin.bad_rcpt(
-        (code, msg) => {
-          assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bad_rcpt'))
-          assert.ok(this.should_skip_spy.calledOnce)
-          assert.equal(code, undefined)
-          assert.equal(msg, undefined)
-          resolve()
-        },
-        this.connection,
-        rcpt,
-      )
-    })
+    this.plugin.bad_rcpt(
+      (code, msg) => {
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bad_rcpt'))
+        assert.ok(this.should_skip_spy.calledOnce)
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+      },
+      this.connection,
+      rcpt,
+    )
   })
 
   it('will check for invalid recipient', async function () {
@@ -509,32 +603,13 @@ describe('bad_rcpt', function () {
   })
 })
 
-describe('has_null_sender', function () {
-  it('has null sender', function () {
-    assert.ok(this.plugin.has_null_sender(this.connection.transaction))
-
-    assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', true))
-  })
-
-  it('has empty string sender', function () {
-    this.connection.transaction.mail_from = new Address.Address('')
-    assert.ok(this.plugin.has_null_sender(this.connection.transaction))
-    assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', true))
-  })
-
-  it('is not a null sender', function () {
-    this.connection.transaction.mail_from = new Address.Address('user@example.com')
-    assert.equal(this.plugin.has_null_sender(this.connection.transaction), false)
-    assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', false))
-  })
-})
-
 describe('bounce_spf_enable', function () {
   it('bounce_spf_enable - missing transaction', async function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.bounce_spf_enable((code, msg) => {
+        assert.ok(this.should_skip_spy.notCalled)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -557,9 +632,11 @@ describe('bounce_spf_enable', function () {
 
   it('is inbound mail', async function () {
     this.connection.relaying = false
+    this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf_enable((code, msg) => {
+        assert.ok(this.should_skip_spy.calledOnce)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         assert.equal(this.connection.transaction.parse_body, true)
@@ -572,7 +649,7 @@ describe('bounce_spf_enable', function () {
 describe('bounce_spf', function () {
   const { SPF } = require('haraka-plugin-spf')
 
-  let check_host_stub, find_received_headers_stub
+  let spf_check_host_stub, find_received_headers_stub
   let spf
 
   beforeEach(function () {
@@ -582,10 +659,11 @@ describe('bounce_spf', function () {
     }
     this.connection.transaction.parse_body = true
     this.connection.transaction.mail_from = new Address.Address('<>')
+    this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
 
     this.plugin.cfg.reject.bounce_spf = true
 
-    check_host_stub = sinon.stub(SPF.prototype, 'check_host')
+    spf_check_host_stub = sinon.stub(SPF.prototype, 'check_host')
     find_received_headers_stub = sinon.stub(this.plugin, 'find_received_headers')
 
     spf = new SPF()
@@ -595,7 +673,7 @@ describe('bounce_spf', function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.bounce_spf((code, msg) => {
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -631,12 +709,13 @@ describe('bounce_spf', function () {
   })
 
   it('will skip when not a null sender', async function () {
+    this.connection.transaction.results.add(this.plugin, { isa: 'no' })
     this.connection.transaction.mail_from = new Address.Address('<test@example.com>')
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
         assert.ok(this.should_skip_spy.calledOnce)
-        assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', false))
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'no'))
         assert.ok(find_received_headers_stub.notCalled)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
@@ -661,18 +740,18 @@ describe('bounce_spf', function () {
     })
   })
 
-  it('no IPs', async function () {
+  it('has no IPs', async function () {
     this.connection.transaction.body.bodytext = ''
 
     find_received_headers_stub.returns(new Set())
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', true))
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
         assert(find_received_headers_stub.calledOnce)
         assert(find_received_headers_stub.calledWith(this.connection.transaction.body))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'no IP addresses found in message'))
-        assert.ok(check_host_stub.notCalled)
+        assert.ok(spf_check_host_stub.notCalled)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -683,16 +762,17 @@ describe('bounce_spf', function () {
   it('has multiple IPs - 1st IP fails, 2nd IP passes', async function () {
     this.connection.transaction.body.bodytext = 'filler'
 
-    find_received_headers_stub.returns(new Set('1.2.3.4', '5.6.7.8'))
-    check_host_stub.returns(spf.SPF_FAIL).returns(spf.SPF_PASS)
+    find_received_headers_stub.returns(new Set(['1.2.3.4', '5.6.7.8']))
+    spf_check_host_stub.onFirstCall().resolves(spf.SPF_FAIL)
+    spf_check_host_stub.onSecondCall().resolves(spf.SPF_PASS)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
         assert(find_received_headers_stub.calledOnce)
-        assert.ok(this.connection.transaction.results.get(this.plugin, 'isa', true))
         assert(find_received_headers_stub.calledWith(this.connection.transaction.body))
+        assert.ok(spf_check_host_stub.calledTwice)
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bounce_spf'))
-        assert.ok(check_host_stub.calledOnce)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -702,11 +782,11 @@ describe('bounce_spf', function () {
 
   it('SPF_TEMPERROR', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_TEMPERROR)
+    spf_check_host_stub.resolves(spf.SPF_TEMPERROR)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned TempError'))
         assert.equal(code, undefined)
@@ -718,11 +798,11 @@ describe('bounce_spf', function () {
 
   it('SPF_PERMERROR', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_PERMERROR)
+    spf_check_host_stub.resolves(spf.SPF_PERMERROR)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned PermError'))
         assert.equal(code, undefined)
@@ -734,11 +814,11 @@ describe('bounce_spf', function () {
 
   it('SPF_NONE', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_NONE)
+    spf_check_host_stub.resolves(spf.SPF_NONE)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'SPF returned None'))
         assert.equal(code, undefined)
@@ -750,11 +830,11 @@ describe('bounce_spf', function () {
 
   it('SPF_PASS', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_PASS)
+    spf_check_host_stub.resolves(spf.SPF_PASS)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'bounce_spf'))
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
@@ -765,11 +845,11 @@ describe('bounce_spf', function () {
 
   it('SPF_NEUTRAL', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_NEUTRAL)
+    spf_check_host_stub.resolves(spf.SPF_NEUTRAL)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
         assert.equal(code, DENY)
@@ -781,11 +861,11 @@ describe('bounce_spf', function () {
 
   it('SPF_SOFTFAIL', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_SOFTFAIL)
+    spf_check_host_stub.resolves(spf.SPF_SOFTFAIL)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
         assert.equal(code, DENY)
@@ -797,13 +877,13 @@ describe('bounce_spf', function () {
 
   it('skip SPF reject', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_FAIL)
+    spf_check_host_stub.resolves(spf.SPF_FAIL)
 
     this.plugin.cfg.reject.bounce_spf = false
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
         assert.equal(code, undefined)
@@ -815,11 +895,11 @@ describe('bounce_spf', function () {
 
   it('SPF_FAIL', async function () {
     find_received_headers_stub.returns(new Set().add('1.2.3.4'))
-    check_host_stub.returns(spf.SPF_FAIL)
+    spf_check_host_stub.resolves(spf.SPF_FAIL)
 
     await new Promise((resolve) => {
       this.plugin.bounce_spf((code, msg) => {
-        assert.ok(check_host_stub.calledOnce)
+        assert.ok(spf_check_host_stub.calledOnce)
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_spf'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid bounce (spoofed sender)'))
         assert.equal(code, DENY)
@@ -831,7 +911,7 @@ describe('bounce_spf', function () {
 })
 
 describe('create_validation_hash', function () {
-  let get_decoded_stub
+  let get_decoded_spy
 
   beforeEach(function () {
     this.connection.transaction.body = {
@@ -843,14 +923,14 @@ describe('create_validation_hash', function () {
     this.connection.relaying = true
     this.plugin.cfg.check.hash_validation = true
 
-    get_decoded_stub = sinon.stub(this.connection.transaction.header, 'get_decoded')
+    get_decoded_spy = sinon.spy(this.connection.transaction.header, 'get_decoded')
   })
 
   it('create_validation_hash - missing transaction', async function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.create_validation_hash((code, msg) => {
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -863,7 +943,7 @@ describe('create_validation_hash', function () {
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.notCalled(get_decoded_stub)
+        sinon.assert.notCalled(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -876,7 +956,7 @@ describe('create_validation_hash', function () {
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.notCalled(get_decoded_stub)
+        sinon.assert.notCalled(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -887,10 +967,11 @@ describe('create_validation_hash', function () {
   it('should skip outbound with null sender', async function () {
     this.connection.transaction.mail_from = new Address.Address('<>')
     this.connection.relaying = true
+    this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.notCalled(get_decoded_stub)
+        sinon.assert.notCalled(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -907,7 +988,7 @@ describe('create_validation_hash', function () {
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.calledThrice(get_decoded_stub)
+        sinon.assert.calledThrice(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -918,7 +999,7 @@ describe('create_validation_hash', function () {
   it('missing From, Date, and Message-ID headers', async function () {
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.calledThrice(get_decoded_stub)
+        sinon.assert.calledThrice(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -937,7 +1018,7 @@ describe('create_validation_hash', function () {
 
     await new Promise((resolve) => {
       this.plugin.create_validation_hash((code, msg) => {
-        sinon.assert.calledThrice(get_decoded_stub)
+        sinon.assert.calledThrice(get_decoded_spy)
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -952,15 +1033,10 @@ describe('validate_bounce', function () {
   let date_header, from_header, message_id
 
   beforeEach(function () {
-    this.plugin.cfg.check.hash_date = true
     this.plugin.cfg.check.hash_validation = true
     this.plugin.cfg.reject.hash_validation = true
-    this.plugin.cfg.reject.hash_date = true
-    this.plugin.cfg.validation = {
-      max_hash_age_days: 6,
-      hash_algorithm: 'sha256',
-      secret: crypto.randomBytes(32).toString('base64'),
-    }
+
+    this.plugin.cfg.whitelist = {}
 
     this.connection.transaction.body = {
       bodytext: '',
@@ -984,7 +1060,7 @@ describe('validate_bounce', function () {
     delete this.connection.transaction
 
     await new Promise((resolve) => {
-      this.plugin.empty_return_path((code, msg) => {
+      this.plugin.validate_bounce((code, msg) => {
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -1005,6 +1081,19 @@ describe('validate_bounce', function () {
     })
   })
 
+  it('will ignore outbound mail', async function () {
+    this.connection.relaying = true
+
+    await new Promise((resolve) => {
+      this.plugin.validate_bounce((code, msg) => {
+        assert.ok(this.should_skip_spy.returned(true))
+        assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
   it('has hash size that is too short', async function () {
     hash = '1234567890'
 
@@ -1018,7 +1107,7 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash length mismatch'))
         assert(find_bounce_headers_stub.calledOnce)
-        assert(find_bounce_headers_stub.calledWith(this.connection.transaction, this.connection.transaction.body))
+        assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -1070,8 +1159,25 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'validate_bounce'))
         assert(find_bounce_headers_stub.calledOnce)
-        assert(find_bounce_headers_stub.calledWith(this.connection.transaction, this.connection.transaction.body))
+        assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
         assert.equal(code, undefined)
+        assert.equal(msg, undefined)
+        resolve()
+      }, this.connection)
+    })
+  })
+
+  it('is a valid inbound bounce and will skip data_post in remaining plugins', async function () {
+    const headers = create_headers(this.plugin)
+    find_bounce_headers_stub.returns(headers)
+    this.plugin.cfg.skip.remaining_plugins = true
+
+    await new Promise((resolve) => {
+      this.plugin.validate_bounce((code, msg) => {
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'pass', 'validate_bounce'))
+        assert(find_bounce_headers_stub.calledOnce)
+        assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
+        assert.equal(code, OK)
         assert.equal(msg, undefined)
         resolve()
       }, this.connection)
@@ -1223,7 +1329,7 @@ describe('validate_bounce', function () {
   })
 
   it('is missing hash header and address parsing fails', async function () {
-    const from = 'mail delivery system <mailer-daemon@example.com>'
+    const from = 'evil-mailer'
     const rcpt = new Address.Address('test@example.com')
 
     this.plugin.cfg.reject.hash_validation = false
@@ -1236,8 +1342,8 @@ describe('validate_bounce', function () {
 
     await new Promise((resolve) => {
       this.plugin.validate_bounce((code, msg) => {
-        assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'validate_bounce'))
-        assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'missing validation hash'))
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'skip', 'validate_bounce'))
+        assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid from header'))
         assert.equal(code, undefined)
         assert.equal(msg, undefined)
         resolve()
@@ -1270,10 +1376,10 @@ describe('validate_bounce', function () {
   })
 
   it('is missing hash header and sender domain is whitelisted', async function () {
-    this.plugin.cfg.whitelist = { 'bar@example.com': ['*@example.net'] }
+    this.plugin.cfg.whitelist = { 'test@example.com': ['*@example.net'] }
 
     const from = '<info@example.net>'
-    const rcpt = new Address.Address('bar@example.com')
+    const rcpt = new Address.Address('test@example.com')
 
     this.connection.transaction.rcpt_to[0] = rcpt
     this.connection.transaction.add_header('From', from)
@@ -1368,7 +1474,6 @@ describe('validate_bounce', function () {
   })
 
   it('will Deny when hash is too old', async function () {
-    this.plugin.cfg.reject.hash_date = true
     const eightDaysAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 8)
     date_header = eightDaysAgo.toUTCString()
 
@@ -1380,7 +1485,7 @@ describe('validate_bounce', function () {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_date'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash is too old'))
         assert(find_bounce_headers_stub.calledOnce)
-        assert(find_bounce_headers_stub.calledWith(this.connection.transaction, this.connection.transaction.body))
+        assert(find_bounce_headers_stub.calledWith(this.connection.transaction.body))
         assert.equal(code, DENY)
         assert.equal(msg, 'invalid bounce')
         resolve()
@@ -1388,29 +1493,7 @@ describe('validate_bounce', function () {
     })
   })
 
-  it('hash is too old', async function () {
-    this.plugin.cfg.reject.hash_date = false
-    const eightDaysAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 8)
-    date_header = eightDaysAgo.toUTCString()
-
-    const headers = create_headers(this.plugin, { date_header })
-    find_bounce_headers_stub.returns(headers)
-
-    await new Promise((resolve) => {
-      this.plugin.validate_bounce((code, msg) => {
-        assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_date'))
-        assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'hash is too old'))
-        assert(find_bounce_headers_stub.calledOnce)
-        assert(find_bounce_headers_stub.calledWith(this.connection.transaction, this.connection.transaction.body))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
-        resolve()
-      }, this.connection)
-    })
-  })
-
   it('has invalid date header', async function () {
-    this.plugin.cfg.reject.hash_date = false
     date_header = 'invalid date'
 
     const headers = create_headers(this.plugin, { date_header })
@@ -1420,8 +1503,8 @@ describe('validate_bounce', function () {
       this.plugin.validate_bounce((code, msg) => {
         assert.ok(this.connection.transaction.results.has(this.plugin, 'fail', 'bounce_date'))
         assert.ok(this.connection.transaction.results.has(this.plugin, 'msg', 'invalid date header'))
-        assert.equal(code, undefined)
-        assert.equal(msg, undefined)
+        assert.equal(code, DENY)
+        assert.equal(msg, 'invalid bounce')
         resolve()
       }, this.connection)
     })
@@ -1445,30 +1528,70 @@ describe('validate_bounce', function () {
   })
 })
 
+describe('is_date_valid', function () {
+  it('has recent date', function () {
+    const oneDayAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 1)
+    const date_header = oneDayAgo.toUTCString()
+
+    const result = this.plugin.is_date_valid(date_header)
+    assert(result.valid)
+  })
+
+  it('has expired date', function () {
+    const SevenDaysAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 7)
+    const date_header = SevenDaysAgo.toUTCString()
+    const result = this.plugin.is_date_valid(date_header)
+    assert.equal(result.valid, false)
+    assert.equal(result.msg, 'hash is too old')
+  })
+
+  it('has invalid date', function () {
+    const not_a_date = 'hello world'
+    const result = this.plugin.is_date_valid(not_a_date)
+    assert.equal(result.valid, false)
+    assert.equal(result.msg, 'invalid date header')
+  })
+})
+
+describe('is_whitelisted', function () {
+  it('is not whitelisted', function () {
+    this.plugin.cfg.whitelist = {}
+
+    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
+
+    assert.equal(whitelisted, false)
+  })
+
+  it('is whitelisted with an exact match', function () {
+    this.plugin.cfg.whitelist = { 'test@example.com': ['support@example.com'] }
+
+    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
+
+    assert.ok(whitelisted)
+  })
+
+  it('is whitelisted with a wildcard match', function () {
+    this.plugin.cfg.whitelist = {
+      'test@example.com': ['support@example.net', '*@example.com'],
+    }
+
+    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
+
+    assert.ok(whitelisted)
+  })
+})
+
 describe('find_bounce_headers', function () {
-  let date_header, from_header, message_id, hash, amalgam
+  let date, from, message_id, hash
   let msg_body, transaction
 
   beforeEach(function () {
-    date_header = new Date().toISOString()
-    from_header = '<test@EXAMPLE.com>'
-    message_id = '<test@example.COM>'
-
-    this.plugin.cfg.validation = {
-      hash_algorithm: 'sha256',
-      secret: crypto.randomBytes(32).toString('base64'),
-    }
-
-    amalgam = `${from_header}:${date_header}:${message_id}`
-    hash = crypto
-      .createHmac(this.plugin.cfg.validation.hash_algorithm, this.plugin.cfg.validation.secret)
-      .update(amalgam)
-      .digest('hex')
+    ;({ from, date, message_id, hash } = create_headers(this.plugin))
 
     msg_body = `
 X-Haraka-Bounce-Validation: ${hash}
-From: ${from_header}
-Date: ${date_header}
+From: ${from}
+Date: ${date}
 Message-ID: ${message_id}
 `
     transaction = this.connection.transaction
@@ -1490,50 +1613,37 @@ Message-ID: ${message_id}
   it('has all headers in body', function () {
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from_header)
-    assert.equal(headers.date, date_header)
+    assert.equal(headers.from, from)
+    assert.equal(headers.date, date)
     assert.equal(headers.message_id, message_id)
     assert.equal(headers.hash, hash)
   })
 
   it('has From header in body', function () {
-    transaction.body.bodytext = `From: ${from_header}\n`
+    transaction.body.bodytext = `From: ${from}
+Content-Type: text/plain`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from_header)
+    assert.equal(headers.from, from)
     assert.equal(headers.date, undefined)
     assert.equal(headers.message_id, undefined)
     assert.equal(headers.hash, undefined)
   })
 
   it('has Date header in body', function () {
-    transaction.body.bodytext = `Date: ${date_header}\n`
+    transaction.body.bodytext = `Date: ${date}\n`
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
     assert.equal(headers.from, undefined)
-    assert.equal(headers.date, date_header)
-    assert.equal(headers.message_id, undefined)
-    assert.equal(headers.hash, undefined)
-  })
-
-  it('has one header in body', function () {
-    transaction.body.bodytext = `Date: ${date_header}\n`
-
-    const headers = this.plugin.find_bounce_headers(transaction.body)
-
-    assert.equal(headers.from, undefined)
-    assert.equal(headers.date, date_header)
+    assert.equal(headers.date, date)
     assert.equal(headers.message_id, undefined)
     assert.equal(headers.hash, undefined)
   })
 
   it('has no headers in body', function () {
-    transaction.body = {
-      bodytext: 'no headers in this body',
-      children: [],
-    }
+    transaction.body.bodytext = 'no headers in this body'
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
@@ -1551,88 +1661,93 @@ Message-ID: ${message_id}
 
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from_header)
-    assert.equal(headers.date, date_header)
+    assert.equal(headers.from, from)
+    assert.equal(headers.date, date)
     assert.equal(headers.message_id, message_id)
     assert.equal(headers.hash, hash)
   })
 
-  it('has folded headers', function () {
-    from_header = `"Dr. Smith - Back & Neck Care Center of San Fransisco" <dr.smith@example.com>`
-    hash = crypto
-      .createHmac(this.plugin.cfg.validation.hash_algorithm, this.plugin.cfg.validation.secret)
-      .update(amalgam)
-      .digest('hex')
+  it('has no headers in body.children', function () {
+    transaction.body = {
+      bodytext: 'Hello World',
+      children: [{ bodytext: 'no headers in this body' }],
+    }
 
+    const headers = this.plugin.find_bounce_headers(transaction.body)
+
+    assert.equal(headers.from, undefined)
+    assert.equal(headers.date, undefined)
+    assert.equal(headers.message_id, undefined)
+    assert.equal(headers.hash, undefined)
+  })
+
+  it('has folded headers', function () {
+    const unfolded_from = `"Dr. Smith - Dr. Smith's Snake Oil Emporium" <dr.smith@example.com>`
+    const folded_from = `"Dr. Smith - Dr. Smith's Snake Oil Emporium"\n  <dr.smith@example.com>`
     transaction.body.bodytext = `
 Message-ID: ${message_id}
-Date: ${date_header}
-From: "Dr. Smith - Back & Neck Care Center of San Fransisco"
-  <dr.smith@example.com>
+Date: ${date}
+From: ${folded_from}
 X-Haraka-Bounce-Validation: ${hash}
 `
     const headers = this.plugin.find_bounce_headers(transaction.body)
 
-    assert.equal(headers.from, from_header)
-    assert.equal(headers.date, date_header)
+    assert.equal(headers.from, unfolded_from)
+    assert.equal(headers.date, date)
     assert.equal(headers.message_id, message_id)
     assert.equal(headers.hash, hash)
   })
 })
 
 describe('should_skip', function () {
-  let has_null_sender_spy
-
-  beforeEach(function () {
-    has_null_sender_spy = sinon.spy(this.plugin, 'has_null_sender')
-  })
-
   it('is relaying and is not a bounce', function () {
     this.connection.transaction.mail_from = new Address.Address('<test@example.com>')
     this.connection.relaying = true
+    this.connection.transaction.results.add(this.plugin, { isa: 'no' })
 
     const result = this.plugin.should_skip(this.connection)
 
     assert.equal(result, true)
-    assert.ok(has_null_sender_spy.calledOnce)
-    assert.ok(has_null_sender_spy.returned(false))
   })
 
   it('is relaying and is a bounce', function () {
     this.connection.relaying = true
+    this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
 
     const result = this.plugin.should_skip(this.connection)
 
     assert.equal(result, true)
-    assert.ok(has_null_sender_spy.calledOnce)
-    assert.ok(has_null_sender_spy.returned(true))
   })
 
   it('is not relaying and is not a bounce', function () {
     this.connection.transaction.mail_from = new Address.Address('<test@example.com>')
     this.connection.relaying = false
+    this.connection.transaction.results.add(this.plugin, { isa: 'no' })
 
     const result = this.plugin.should_skip(this.connection)
 
     assert.equal(result, true)
-    assert.ok(has_null_sender_spy.calledOnce)
-    assert.ok(has_null_sender_spy.returned(false))
   })
 
   it('is not relaying and is a bounce', function () {
     this.connection.relaying = false
+    this.connection.transaction.results.add(this.plugin, { isa: 'yes' })
 
     const result = this.plugin.should_skip(this.connection)
 
     assert.equal(result, false)
-    assert.ok(has_null_sender_spy.calledOnce)
-    assert.ok(has_null_sender_spy.returned(true))
   })
 })
 
 describe('find_received_headers', function () {
   beforeEach(function () {
     this.connection.transaction.body = { bodytext: '', children: [] }
+  })
+
+  it('has no body', function () {
+    const ips = this.plugin.find_received_headers('')
+
+    assert.equal(ips.size, 0)
   })
 
   it('has no Received headers', function () {
@@ -1720,67 +1835,124 @@ Received: from mail.example.com (mail.example.com [${ip2}])
   })
 })
 
-describe('is_date_valid', function () {
+describe('extract_header', function () {
+  let bodytext, from, date, message_id, hash
+
   beforeEach(function () {
-    this.plugin.cfg.validation.max_hash_age_days = 6
+    ;({ from, date, message_id, hash } = create_headers(this.plugin))
+
+    bodytext = `From: ${from}
+Date: ${date}
+Message-ID: ${message_id}
+X-Haraka-Bounce-Validation: ${hash}
+`
   })
 
-  it('has recent date', function () {
-    const oneDayAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 1)
-    const date_header = oneDayAgo.toUTCString()
+  it('should return undefined if bodytext is missing', function () {
+    bodytext = null
 
-    const result = this.plugin.is_date_valid(date_header)
-    assert(result.valid)
+    const value = this.plugin.extract_header(bodytext, 'From')
+
+    assert.strictEqual(value, undefined)
   })
 
-  it('has expired date', function () {
-    const SevenDaysAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 7)
-    const date_header = SevenDaysAgo.toUTCString()
-    const result = this.plugin.is_date_valid(date_header)
-    assert.equal(result.valid, false)
-    assert.equal(result.msg, 'hash is too old')
+  it('should return undefined if bodytext is not a string', function () {
+    bodytext = {}
+
+    const value = this.plugin.extract_header(bodytext, 'From')
+
+    assert.strictEqual(value, undefined)
   })
 
-  it('has invalid date', function () {
-    const not_a_date = 'hello world'
-    const result = this.plugin.is_date_valid(not_a_date)
-    assert.equal(result.valid, false)
-    assert.equal(result.msg, 'invalid date header')
+  it('should extract the From header', function () {
+    const value = this.plugin.extract_header(bodytext, 'From')
+
+    assert.strictEqual(value, from)
+  })
+
+  it('should extract the Date header', function () {
+    const value = this.plugin.extract_header(bodytext, 'Date')
+
+    assert.strictEqual(value, date)
+  })
+
+  it('should extract the Message-ID header', function () {
+    const value = this.plugin.extract_header(bodytext, 'Message-ID')
+
+    assert.strictEqual(value, message_id)
+  })
+
+  it('should extract the X-Haraka-Bounce-Validation header', function () {
+    const value = this.plugin.extract_header(bodytext, 'X-Haraka-Bounce-Validation')
+
+    assert.strictEqual(value, hash)
+  })
+
+  it('should extract the folded From header', function () {
+    const from_header = `"Dr. Smith - Dr. Smith's Snake Oil Emporium" <dr.smith@example.com>`
+
+    bodytext = `From: "Dr. Smith - Dr. Smith's Snake Oil Emporium"
+  <dr.smith@example.com>
+Date: ${date}
+Message-ID: ${message_id}
+X-Haraka-Bounce-Validation: ${hash}
+`
+    const value = this.plugin.extract_header(bodytext, 'From')
+
+    assert.strictEqual(value, from_header)
+  })
+
+  it('should not extract anything', function () {
+    const value = this.plugin.extract_header(bodytext, 'In-Reply-To')
+
+    assert.strictEqual(value, undefined)
   })
 })
 
-describe('is_whitelisted', function () {
-  it('is not whitelisted', function () {
-    this.plugin.cfg.whitelist = {}
-
-    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
-
-    assert.equal(whitelisted, false)
+describe('check_null_sender', function () {
+  it('is relaying', function () {
+    this.connection.relaying = true
+    this.plugin.check_null_sender((code, msg) => {
+      assert.strictEqual(this.connection.transaction.results.get(this.plugin), undefined)
+      assert.equal(code, undefined)
+      assert.equal(msg, undefined)
+    }, this.connection)
   })
 
-  it('is whitelisted with an exact match', function () {
-    this.plugin.cfg.whitelist = { 'test@example.com': ['support@example.com'] }
-
-    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
-
-    assert.ok(whitelisted)
+  it('has null sender', function () {
+    this.plugin.check_null_sender((code, msg) => {
+      assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
+      assert.equal(code, undefined)
+      assert.equal(msg, undefined)
+    }, this.connection)
   })
 
-  it('is whitelisted with a wildcard match', function () {
-    this.plugin.cfg.whitelist = {
-      'test@example.com': ['support@example.net', '*@example.com'],
-    }
+  it('has empty string sender', function () {
+    this.connection.transaction.mail_from = new Address.Address('')
 
-    const whitelisted = this.plugin.is_whitelisted('test@example.com', 'support@example.com')
+    this.plugin.check_null_sender((code, msg) => {
+      assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'yes'))
+      assert.equal(code, undefined)
+      assert.equal(msg, undefined)
+    }, this.connection)
+  })
 
-    assert.ok(whitelisted)
+  it('is not a null sender', function () {
+    this.connection.transaction.mail_from = new Address.Address('user@example.com')
+
+    this.plugin.check_null_sender((code, msg) => {
+      assert.ok(this.connection.transaction.results.has(this.plugin, 'isa', 'no'))
+      assert.equal(code, undefined)
+      assert.equal(msg, undefined)
+    }, this.connection)
   })
 })
 
 function create_headers(plugin, options = {}) {
   const date_header = options.date_header || new Date().toISOString()
-  const from_header = options.from_header || '<test@example.com>'
-  const message_id = options.message_id || '<test@example.com>'
+  //const date_header = options.date_header || 'Sun, 9 Nov 2025 06:21:23 GMT'
+  const from_header = options.from_header || 'test <test@example.com>'
+  const message_id = options.message_id || '<PB8-DCB-KHNZ4Y5J3N0Z@example.com>'
 
   let hash = options.hash
   if (!hash) {

--- a/test/index.js
+++ b/test/index.js
@@ -1949,7 +1949,6 @@ describe('check_null_sender', function () {
 
 function create_headers(plugin, options = {}) {
   const date_header = options.date_header || new Date().toISOString()
-  //const date_header = options.date_header || 'Sun, 9 Nov 2025 06:21:23 GMT'
   const from_header = options.from_header || 'test <test@example.com>'
   const message_id = options.message_id || '<PB8-DCB-KHNZ4Y5J3N0Z@example.com>'
 


### PR DESCRIPTION
Changes proposed in this pull request:

- moved null sender check to hook_mail (check_null_sender)
- exported extract_header() for testing
- removed check.hash_date and reject.hash_date
- will always reject bounces with expired or invalid date header
- added test coverage
- refactored load_bounce_whitelist
- refactored extract_header to correctly capture folded headers
- fixed some testing bugs
- added test coverage
- added tests
- removed config options to check/reject if Date header is too old or invalid. now always reject bounces with expired or invalid date header.
- bumped version to 2.1.3

Checklist:

- [ ] docs updated
- [X] tests updated
- [X] Changes.md updated
- [X] package.json.version bumped
