### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.2.0] - 2026-05-15
+
+- fix: prevent stateful regex leaking across recursive MIME-part scan
+- dep(address-rfc2822): replaced by @haraka/email-address
 - doc(README): fixed the feature-toggle sentence
 - doc(README): removed duplicate hash_date=false
-- fix: prevent stateful regex leaking across recursive MIME-part scan
-- moved null sender check to hook_mail
+- changed: moved null sender check to hook_mail
 - test: runner is now node:test
 - test: convert done callbacks to async/await #20
 
@@ -144,3 +147,4 @@ Changes to README.md
 [2.1.1]: https://github.com/haraka/haraka-plugin-bounce/releases/tag/v2.1.1
 [2.1.0]: https://github.com/haraka/haraka-plugin-bounce/releases/tag/v2.1.0
 [2.1.2]: https://github.com/haraka/haraka-plugin-bounce/releases/tag/v2.1.2
+[2.2.0]: https://github.com/haraka/haraka-plugin-bounce/releases/tag/v2.2.0

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const { SPF } = require('haraka-plugin-spf')
 const net_utils = require('haraka-net-utils')
 const crypto = require('node:crypto')
-const addrparser = require('address-rfc2822')
+const addrparser = require('@haraka/email-address')
 
 const MAX_HASH_AGE_DAYS = 6
 
@@ -259,13 +259,13 @@ exports.bad_rcpt = function (next, connection, rcpt) {
 
   const { transaction } = connection
 
-  if (this.cfg.invalid_addrs.includes(rcpt.address().toLowerCase())) {
+  if (this.cfg.invalid_addrs.includes(rcpt.address.toLowerCase())) {
     transaction.results.add(this, {
       fail: 'bad_rcpt',
       msg: 'rcpt does not accept bounces',
       emit: true,
     })
-    return next(DENY, `${rcpt.address()} does not accept bounces`)
+    return next(DENY, `${rcpt.address} does not accept bounces`)
   }
 
   transaction.results.add(this, { pass: 'bad_rcpt' })
@@ -549,7 +549,7 @@ exports.validate_bounce = function (next, connection) {
       parsed_from = addrparser.parseHeader(from_header)[0].address
     } catch (err) {
       // ignore error
-      connection.loginfo(this, `address-rfc2822 parsing error: ${err.message}`)
+      connection.loginfo(this, `@haraka/email-address parsing error: ${err.message}`)
 
       transaction.results.add(this, {
         skip: 'validate_bounce',
@@ -559,7 +559,7 @@ exports.validate_bounce = function (next, connection) {
       return next()
     }
 
-    const rcpt = transaction.rcpt_to[0].address().toLowerCase()
+    const rcpt = transaction.rcpt_to[0].address.toLowerCase()
 
     if (this.is_whitelisted(rcpt, parsed_from)) {
       transaction.results.add(this, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-bounce",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Provide multiple configurable strategies to detect, validate, and process email bounces",
   "main": "index.js",
   "files": [
@@ -35,14 +35,13 @@
   },
   "homepage": "https://github.com/haraka/haraka-plugin-bounce#readme",
   "dependencies": {
-    "address-rfc2822": "^2.2.3",
+    "@haraka/email-address": "^3.1.4",
     "haraka-net-utils": "^1.8.2",
     "haraka-plugin-spf": "^1.2.11"
   },
   "devDependencies": {
-    "address-rfc2821": "^2.2.0",
     "@haraka/eslint-config": "^2.0.4",
-    "haraka-test-fixtures": "~1.4.1",
+    "haraka-test-fixtures": "^1.6.0",
     "sinon": "^22.0.0"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "versions": "npx npm-dep-mgr check",
     "versions:fix": "npx npm-dep-mgr update",
     "test:coverage": "node --test --experimental-test-coverage --test-coverage-exclude=package.json --test-coverage-exclude=test/*.js test/*.js",
-    "test:coverage:lcov": "mkdir -p coverage && node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
+    "test:coverage:lcov": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-exclude=package.json --test-coverage-exclude=test/*.js --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/config.js
+++ b/test/config.js
@@ -5,7 +5,7 @@ const crypto = require('node:crypto')
 const { describe, it, beforeEach, afterEach } = require('node:test')
 const sinon = require('sinon')
 
-const { Address } = require('address-rfc2821')
+const { Address } = require('@haraka/email-address')
 const fixtures = require('haraka-test-fixtures')
 
 let plugin, connection, should_skip_spy

--- a/test/reject.js
+++ b/test/reject.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach, afterEach } = require('node:test')
 const sinon = require('sinon')
 
-const { Address } = require('address-rfc2821')
+const { Address } = require('@haraka/email-address')
 const fixtures = require('haraka-test-fixtures')
 
 let plugin, connection, should_skip_spy
@@ -214,6 +214,6 @@ describe('bad_rcpt', () => {
     assert.ok(connection.transaction.results.has(plugin, 'msg', 'rcpt does not accept bounces'))
     assert.ok(should_skip_spy.calledOnce)
     assert.equal(code, DENY)
-    assert.equal(msg, `${rcpt.address()} does not accept bounces`)
+    assert.equal(msg, `${rcpt.address} does not accept bounces`)
   })
 })

--- a/test/spf.js
+++ b/test/spf.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach, afterEach } = require('node:test')
 const sinon = require('sinon')
 
-const { Address } = require('address-rfc2821')
+const { Address } = require('@haraka/email-address')
 const fixtures = require('haraka-test-fixtures')
 
 let plugin, connection, should_skip_spy

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach, afterEach } = require('node:test')
 const sinon = require('sinon')
 
-const { Address } = require('address-rfc2821')
+const { Address } = require('@haraka/email-address')
 const fixtures = require('haraka-test-fixtures')
 
 let plugin, connection, should_skip_spy

--- a/test/validation.js
+++ b/test/validation.js
@@ -5,7 +5,7 @@ const crypto = require('node:crypto')
 const { describe, it, beforeEach, afterEach } = require('node:test')
 const sinon = require('sinon')
 
-const { Address } = require('address-rfc2821')
+const { Address } = require('@haraka/email-address')
 const fixtures = require('haraka-test-fixtures')
 
 let plugin, connection, should_skip_spy


### PR DESCRIPTION
- deps(all): bump versions to latest
- dep(address-rfc2822): replaced by @haraka/email-address
- test: runner is now node:test
- test: convert done callbacks to async/await #20

Part of https://github.com/haraka/Haraka/issues/3564